### PR TITLE
source maps support for opal >= 0.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-jquery'
 end
 
-gem 'opal'
+gem 'opal', '>= 0.8.0'
 gem 'opal-jquery'
 gem 'slim'
 gem 'sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,35 +3,34 @@ GEM
   remote: https://rails-assets.org/
   specs:
     hike (1.2.3)
-    multi_json (1.11.0)
-    opal (0.7.2)
+    opal (0.8.0)
       hike (~> 1.2)
       sourcemap (~> 0.1.0)
-      sprockets (>= 2.2.3, < 3.0.0)
-      tilt (~> 1.4)
-    opal-jquery (0.3.0)
-      opal (~> 0.7.0)
-    rack (1.6.0)
+      sprockets (~> 3.1)
+      tilt (>= 1.4)
+    opal-jquery (0.4.0)
+      opal (>= 0.7.0, < 0.9.0)
+    rack (1.6.4)
     rails-assets-jquery (2.1.4)
-    sass (3.4.13)
-    slim (3.0.3)
+    sass (3.4.19)
+    slim (3.0.6)
       temple (~> 0.7.3)
       tilt (>= 1.3.3, < 2.1)
     sourcemap (0.1.1)
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    temple (0.7.5)
-    tilt (1.4.1)
+    sprockets (3.4.0)
+      rack (> 1, < 3)
+    temple (0.7.6)
+    tilt (2.0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  opal
+  opal (>= 0.8.0)
   opal-jquery
   rails-assets-jquery!
   sass
   slim
+
+BUNDLED WITH
+   1.10.6

--- a/config.ru
+++ b/config.ru
@@ -7,7 +7,7 @@ sprockets = Sprockets::Environment.new.tap do |s|
   s.register_engine '.slim', Slim::Template
 
   # register opal
-  s.register_engine '.rb', Opal::Processor
+  # s.register_engine '.rb', Opal::Processor
 
   # add folders
   s.append_path 'app'
@@ -15,9 +15,9 @@ sprockets = Sprockets::Environment.new.tap do |s|
   s.append_path 'styles'
 
   # add paths from opal
-  Opal.paths.each do |p|
-    s.append_path p
-  end
+  # Opal.paths.each do |p|
+  #   s.append_path p
+  # end
 
   # add paths from rails-assets
   RailsAssets.load_paths.each do |p|
@@ -25,8 +25,10 @@ sprockets = Sprockets::Environment.new.tap do |s|
   end
 end
 
-Opal::Processor.source_map_enabled = false
+run Opal::Server.new(sprockets: sprockets) {|s|
+      # the name of the ruby file to load. To use more files they must be required from here (see app)
+      s.main = 'app'
+      # need to set the index explicitly for opal server to pick it up
+      s.index_path = 'views/index.html.slim'
 
-map '/' do
-  run sprockets
-end
+    }

--- a/views/index.html.slim
+++ b/views/index.html.slim
@@ -2,8 +2,8 @@ doctype html
 html
   head
     title Hello
-    link href='style.css' rel='stylesheet' type='text/css'
-    script src='app.js'
+    link href='assets/style' rel='stylesheet' type='text/css'
+    == javascript_include_tag 'app'
   body
     h2#element
     button#button ClickMe


### PR DESCRIPTION
in `opal-edge` branch source_maps stops working after bundle update to `opal 0.8.0` ( was `0.8.0.beta1`)
